### PR TITLE
Change symlink example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ These extensions target IPython master, so may not always work on the latest sta
 You can install each extension individually, or you can link the extension directories
 into your IPython directories (what I do):
 
-    ln -s $(pwd)/extensions $(ipython locate)/extensions
-    ln -s $(pwd)/nbextensions $(ipython locate)/nbextensions
+    ln -s $(pwd)/extensions/* $(ipython locate)/extensions
+    ln -s $(pwd)/nbextensions/* $(ipython locate)/nbextensions
 
 ## Gist
 


### PR DESCRIPTION
no longer does it link a same-named folder as a subfolder in the config profile area, but links all extensions from the intended folders.