### PR TITLE
ToC reload button and less horizontal space

### DIFF
--- a/nbextensions/toc.css
+++ b/nbextensions/toc.css
@@ -1,7 +1,9 @@
 /*extracted from https://gist.github.com/magican/5574556*/
+
 #toc {
-  overflow-y: scroll;
+  overflow-y: auto;
   max-height: 300px;
+  padding: 0px;
 
   ol.nested {
     counter-reset: item;
@@ -19,7 +21,7 @@
 #toc-wrapper {
   position: fixed;
   top: 120px;
-  max-width:430px;
+  max-width:230px;
   right: 20px;
   border: thin solid rgba(0, 0, 0, 0.38);
   border-radius: 5px;
@@ -46,3 +48,17 @@
   font-family: monospace;
 }
 
+#toc-wrapper .reload-btn {
+  font-size: 14px;
+  font-family: monospace;
+}
+
+
+/* don't waste so much screen space... */
+#toc-wrapper .toc-item{
+  padding-left: 20px;
+}
+
+#toc-wrapper .toc-item .toc-item{
+  padding-left: 10px;
+}

--- a/nbextensions/toc.js
+++ b/nbextensions/toc.js
@@ -47,16 +47,31 @@ define(["require", "jquery", "base/js/namespace"], function (require, $, IPython
         $('#toc').slideToggle();
         $('#toc-wrapper').toggleClass('closed');
         if ($('#toc-wrapper').hasClass('closed')){
-          $('#toc-wrapper .hide-btn').text('[+]');
+          $('#toc-wrapper .hide-btn')
+          .text('[+]')
+          .attr('title', 'Show ToC');
         } else {
-          $('#toc-wrapper .hide-btn').text('[-]');
+          $('#toc-wrapper .hide-btn')
+          .text('[-]')
+          .attr('title', 'Hide ToC');
         }
         return false;
       }).append(
         $("<a/>")
         .attr("href", "#")
         .addClass("hide-btn")
+        .attr('title', 'Hide ToC')
         .text("[-]")
+      ).append(
+        $("<a/>")
+        .attr("href", "#")
+        .addClass("reload-btn")
+        .text("  \u21BB")
+        .attr('title', 'Reload ToC')
+        .click( function(){
+          table_of_contents();
+          return false;
+        })
       )
     ).append(
         $("<div/>").attr("id", "toc")

--- a/nbextensions/toc.js
+++ b/nbextensions/toc.js
@@ -89,6 +89,7 @@ define(["require", "jquery", "base/js/namespace"], function (require, $, IPython
     }
   
     var ol = $("<ol/>");
+    ol.addClass("toc-item");
     $("#toc").empty().append(ol);
     
     $("#notebook").find(":header").map(function (i, h) {
@@ -103,6 +104,7 @@ define(["require", "jquery", "base/js/namespace"], function (require, $, IPython
       // walk down levels
       for (; depth < level; depth++) {
         var new_ol = $("<ol/>");
+        new_ol.addClass("toc-item");
         ol.append(new_ol);
         ol = new_ol;
       }


### PR DESCRIPTION
This adds two things:

* a reload button, so that the ToC can be reloaded without having to reload the page
* less horizontal space: no scollbars if they are not needed, less padding on the left side of the lists, less wide ToC

This is tested on a Win7, Chrome latest, 1400*900 laptop, where the Toc now takes up the space between the left side of a cell and the normal scrollbar of the browser (in full screen modus). I added 20+ toplevel headings and it displayed ok.

Also opened it in firefox and tried out the new reload button and it worked.