### PR TITLE
Update ToC when notebook is saved

### DIFF
--- a/nbextensions/toc.js
+++ b/nbextensions/toc.js
@@ -161,6 +161,7 @@ define(["require", "jquery", "base/js/namespace"], function (require, $, IPython
     load_css();
     toc_button();
     // $([IPython.events]).on("notebook_loaded.Notebook", table_of_contents);
+    $([IPython.events]).on("notebook_saved.Notebook", table_of_contents);
   };
 
   return {


### PR DESCRIPTION
This automatically updates the table of contents every time the notebook is saved. It's just a single-line change that registers an event listener when the extension is loaded.

This also partially addresses #42 -- I would have liked to update the ToC when Markdown cells are executed, but only have a limited understanding of IPython events.

Event identifier taken from here:
https://github.com/ipython/ipython/wiki/Dev:-Javascript-Events