### PR TITLE
allow dublicate headlines in toc extension

### DIFF
--- a/nbextensions/toc.js
+++ b/nbextensions/toc.js
@@ -17,13 +17,26 @@ toc.load_ipython_extension();
 define(["require", "jquery", "base/js/namespace"], function (require, $, IPython) {
   "use strict";
 
+  var rand = function() {
+	   return Math.random().toString(36).substr(2); // remove `0.`
+  };
+
   var make_link = function (h) {
+
     var a = $("<a/>");
-    a.attr("href", '#' + h.attr('id'));
+
+
     // get the text *excluding* the link text, whatever it may be
     var hclone = h.clone();
     hclone.children().remove();
     a.text(hclone.text());
+
+    var newID = hclone.text().toLowerCase().replace(/[^\w ]+/g,'').replace(/ +/g,'-') + '_' + rand();
+
+
+    h.attr('id', newID);
+    a.attr("href", '#' + newID);
+
     return a;
   };
 


### PR DESCRIPTION
Adds a random hash to the id and link of each heading in the toc
extension.