### PR TITLE
Fix github url for gist extension

### DIFF
--- a/nbextensions/gist.js
+++ b/nbextensions/gist.js
@@ -19,7 +19,7 @@ define( function () {
     var token_dialog = function () {
         var dialog = $('<div/>').append(
             $("<p/>")
-                .html('Enter a <a href="https://github.com/settings/applications" target="_blank">GitHub OAuth token</a>:')
+                .html('Enter a <a href="https://github.com/settings/tokens" target="_blank">GitHub personal access token</a>:')
         ).append(
             $("<br/>")
         ).append(


### PR DESCRIPTION
Github changed their url structure and name for the personal token service. The original link no longer takes you to the right place.